### PR TITLE
Added: Blacklisting of certain workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Or install it yourself as:
 
     $ gem install sidekiq-skylight
 
+## Blacklisted Jobs
+
+If there's a job that you don't want to be instrumented via Skylight, you can
+use the `blacklisted_workers` config option like so:
+
+```ruby
+Sidekiq::Skylight.configure do |config|
+  config.blacklisted_workers = ['BlacklistedWorker']
+end
+```
+
+Any workers with the class names you specify will be ignored from any Skylight tracing.
+
 ## Usage
 
 Make sure you've setup skylight.io for your project already. Everything else should be automatic.

--- a/lib/sidekiq/skylight.rb
+++ b/lib/sidekiq/skylight.rb
@@ -2,6 +2,7 @@ require 'sidekiq'
 
 require_relative 'skylight/version'
 require_relative 'skylight/server_middleware'
+require_relative 'skylight/configuration'
 
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|

--- a/lib/sidekiq/skylight/configuration.rb
+++ b/lib/sidekiq/skylight/configuration.rb
@@ -1,0 +1,19 @@
+module Sidekiq
+  module Skylight
+    class Configuration
+      attr_accessor :blacklisted_workers
+
+      def blacklisted_workers
+        @blacklisted_workers ||= []
+      end
+    end
+
+    def self.config
+      @configuration ||= Configuration.new
+    end
+
+    def self.configure
+      yield config
+    end
+  end
+end

--- a/lib/sidekiq/skylight/server_middleware.rb
+++ b/lib/sidekiq/skylight/server_middleware.rb
@@ -4,9 +4,15 @@ module Sidekiq
   module Skylight
     class ServerMiddleware
       def call(worker, job, queue)
+        return if config.blacklisted_workers.include? worker.class.name
+
         ::Skylight.trace("#{worker.class.to_s}#perform", 'app.sidekiq.worker', 'process') do
           yield
         end
+      end
+
+      def config
+        Sidekiq::Skylight.config
       end
     end
   end

--- a/spec/sidekiq/skylight/server_middleware_spec.rb
+++ b/spec/sidekiq/skylight/server_middleware_spec.rb
@@ -3,11 +3,33 @@ require 'spec_helper'
 describe Sidekiq::Skylight::ServerMiddleware do
   subject(:middleware){described_class.new}
 
+  let(:configuration) { Sidekiq::Skylight::Configuration.new }
+
   FakeWorker = Class.new
+  BlacklistedWorker = Class.new
 
   it 'wraps block in skylight instrument' do
     expect(::Skylight).to receive(:trace).with('FakeWorker#perform', 'app.sidekiq.worker', 'process'){|&block| block.call}
 
     expect{|probe| middleware.call(FakeWorker.new, double(:job), double(:queue), &probe)}.to yield_control
+  end
+
+  it 'does not instrument a blacklisted worker' do
+    configuration.blacklisted_workers = ['BlacklistedWorker']
+
+    allow(::Skylight).to receive(:trace)
+    allow(Sidekiq::Skylight).to receive(:config).and_return(configuration)
+
+    middleware.call(BlacklistedWorker.new, double(:job), double(:queue)) do
+      puts 'running my blacklisted job'
+    end
+
+    expect(::Skylight).not_to have_received(:trace)
+
+    middleware.call(FakeWorker.new, double(:job), double(:queue)) do
+      puts 'running my job'
+    end
+
+    expect(::Skylight).to have_received(:trace)
   end
 end


### PR DESCRIPTION
This is important for some users who have jobs which run an exceedingly large
number of times per day.  For example, if a worker runs every second or every
5 seconds.

Since skylight charges by the request, it's economical to filter these frequent
workers from the list.

---

Actions:
- Closes #2
