### PR TITLE
Allow the inclusion of a blacklisted module to mark a worker as blacklisted

### DIFF
--- a/lib/sidekiq/skylight.rb
+++ b/lib/sidekiq/skylight.rb
@@ -2,6 +2,7 @@ require 'sidekiq'
 
 require_relative 'skylight/version'
 require_relative 'skylight/server_middleware'
+require_relative 'skylight/blacklisted'
 require_relative 'skylight/configuration'
 
 Sidekiq.configure_server do |config|

--- a/lib/sidekiq/skylight/blacklisted.rb
+++ b/lib/sidekiq/skylight/blacklisted.rb
@@ -1,0 +1,9 @@
+module Sidekiq
+  module Skylight
+    module Blacklisted
+      def blacklisted?
+        true
+      end
+    end
+  end
+end

--- a/lib/sidekiq/skylight/blacklisted.rb
+++ b/lib/sidekiq/skylight/blacklisted.rb
@@ -1,7 +1,7 @@
 module Sidekiq
   module Skylight
     module Blacklisted
-      def blacklisted?
+      def blacklisted_for_skylight?
         true
       end
     end

--- a/lib/sidekiq/skylight/server_middleware.rb
+++ b/lib/sidekiq/skylight/server_middleware.rb
@@ -20,7 +20,8 @@ module Sidekiq
 
       def blacklisted?(worker, name)
         config.blacklisted_workers.include?(name) ||
-          (worker.respond_to?(:blacklisted?) && worker.blacklisted?)
+          (worker.respond_to?(:blacklisted_for_skylight?) &&
+           worker.blacklisted_for_skylight?)
       end
 
       def expand_worker_name(worker, job)

--- a/spec/sidekiq/skylight/server_middleware_spec.rb
+++ b/spec/sidekiq/skylight/server_middleware_spec.rb
@@ -5,37 +5,51 @@ describe Sidekiq::Skylight::ServerMiddleware do
 
   FakeWorker = Class.new
   BlacklistedWorker = Class.new
+  BlacklistedWorkerByType = Class.new
+  BlacklistedWorkerByType.include(Sidekiq::Skylight::Blacklisted)
 
-  it 'wraps block in skylight instrument' do
-    expect(::Skylight).to receive(:trace).with('FakeWorker#perform', 'app.sidekiq.worker', 'process') do |&block|
-      block.call
+  shared_examples "an unblacklisted worker" do
+    it 'wraps block in skylight instrument' do
+      expect(::Skylight)
+        .to receive(:trace)
+        .with('FakeWorker#perform', 'app.sidekiq.worker', 'process')
+        .and_yield
+      expect { |probe| middleware.call(FakeWorker.new, {}, double(:queue), &probe) }
+        .to yield_control
     end
-
-    expect{|probe| middleware.call(FakeWorker.new, {}, double(:queue), &probe)}.to yield_control
   end
 
+  it_behaves_like "an unblacklisted worker"
+
   context 'with blacklisted workers' do
-    around(:each) do |example|
-      previous_blacklisted = Sidekiq::Skylight.config.blacklisted_workers
-      Sidekiq::Skylight.config.blacklisted_workers = %w(BlacklistedWorker)
+    context "based on configuration" do
+      around(:each) do |example|
+        previous_blacklisted = Sidekiq::Skylight.config.blacklisted_workers
+        Sidekiq::Skylight.config.blacklisted_workers = %w(BlacklistedWorker)
 
-      example.run
+        example.run
 
-      Sidekiq::Skylight.config.blacklisted_workers = previous_blacklisted
-    end
-
-    it 'does not instrument a blacklisted worker' do
-      expect(::Skylight).to_not receive(:trace)
-
-      expect{|probe| middleware.call(BlacklistedWorker.new, {}, double(:queue), &probe)}.to yield_control
-    end
-
-    it 'still instruments non-blacklisted workers' do
-      expect(::Skylight).to receive(:trace).with('FakeWorker#perform', 'app.sidekiq.worker', 'process') do |&block|
-        block.call
+        Sidekiq::Skylight.config.blacklisted_workers = previous_blacklisted
       end
 
-      expect{|probe| middleware.call(FakeWorker.new, {}, double(:queue), &probe)}.to yield_control
+      it 'does not instrument a blacklisted worker' do
+        expect(::Skylight).to_not receive(:trace)
+
+        expect{|probe| middleware.call(BlacklistedWorker.new, {}, double(:queue), &probe)}.to yield_control
+      end
+
+      it_behaves_like "an unblacklisted worker"
+    end
+
+    context "based on type" do
+      it 'does not instrument a blacklisted worker' do
+        expect(::Skylight).to_not receive(:trace)
+
+        expect { |probe| middleware.call(BlacklistedWorkerByType.new, {}, double(:queue), &probe) }
+          .to yield_control
+      end
+
+      it_behaves_like "an unblacklisted worker"
     end
   end
 


### PR DESCRIPTION
As discussed in issue #6 This will allow the inclusion of a blacklisted module to skip tracing specific workers.
