### PR TITLE
disallow Skylight versions >= 4

### DIFF
--- a/sidekiq-skylight.gemspec
+++ b/sidekiq-skylight.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'sidekiq', '>= 3.3.0'
-  spec.add_runtime_dependency 'skylight', '>= 0.5.2'
+  spec.add_runtime_dependency 'skylight', '>= 0.5.2', '< 4'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
[disclaimer: I work on Skylight at Tilde]

Skylight 4.0 includes built-in instrumentation for Sidekiq and ActiveJob. Users who have activated these new features have reported errors when used alongside `sidekiq-skylight`:

```
ArgumentError: wrong number of arguments (given 1, expected 0)
  from sidekiq/middleware/chain.rb:126:in `block in invoke'
  from skylight/core/instrumentable.rb:104:in `block in trace'
  from skylight/core/instrumenter.rb:126:in `trace'
  from skylight/core/instrumentable.rb:104:in `trace'
  from sidekiq/skylight/server_middleware.rb:11:in `call'      << middleware from sidekiq-skylight
  from sidekiq/middleware/chain.rb:130:in `block in invoke'
  from skylight/core/sidekiq.rb:27:in `block in call'      << built in middleware
  from skylight/core/instrumenter.rb:142:in `trace'
  from skylight/core/sidekiq.rb:25:in `call'
  from sidekiq/middleware/chain.rb:130:in `block in invoke'
  ...
```

We believe usage of this gem should be deprecated except in cases where users are unable to upgrade their Skylight gem to 4.0 (e.g., if using a Rails version < 4.2). Given that the previous dependency specification was open-ended, this PR doesn't solve the problem of previous versions of `sidekiq-skylight` in the wild, which will continue to resolve even for bundles including Skylight 4.0 and above. Would you be open to putting a deprecation notice in the README for better visibility?